### PR TITLE
chore: set source token/chain to eth on loading points tab

### DIFF
--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -482,7 +482,7 @@ const EarnComponent: React.FC = () => {
   return (
     <div className="flex h-full w-full items-start justify-center min-h-[500px]">
       <div className="w-full flex flex-col items-center">
-        <div className="w-[800px] flex justify-center mb-6 mt-6">
+        <div className="w-[880px] flex justify-center mb-6 mt-6">
           {tabs.map((tab) => (
             <Button
               key={tab.id}
@@ -519,24 +519,24 @@ const EarnComponent: React.FC = () => {
           ))}
         </div>
         {activeTab === "yield" && (
-          <div className="w-[800px] bg-zinc-900 rounded-[6px] overflow-hidden">
-            <div className="px-8 py-4">
+          <div className="w-[880px] bg-zinc-900 rounded-[6px] overflow-hidden">
+            <div className="px-6 py-3">
               <table className="w-full border-collapse">
                 <thead>
                   <tr className="border-b border-zinc-800">
-                    <th className="p-4 text-left text-zinc-400 font-medium w-[28%]">
+                    <th className="p-3 text-left text-zinc-400 font-medium w-[28%]">
                       Vault
                     </th>
-                    <th className="p-4 text-left text-zinc-400 font-medium w-[13%]">
+                    <th className="p-3 text-left text-zinc-400 font-medium w-[13%]">
                       Type
                     </th>
-                    <th className="p-4 text-left text-zinc-400 font-medium w-[31%] pr-0">
+                    <th className="p-3 text-left text-zinc-400 font-medium w-[31%] pr-0">
                       Token
                     </th>
-                    <th className="p-4 text-center text-zinc-400 font-medium w-[12%] pl-0">
+                    <th className="p-3 text-left text-zinc-400 font-medium w-[12%] pl-0">
                       APY
                     </th>
-                    <th className="p-4 text-right text-zinc-400 font-medium w-[16%]">
+                    <th className="p-3 text-right text-zinc-400 font-medium w-[16%]">
                       TVL
                     </th>
                   </tr>
@@ -548,7 +548,7 @@ const EarnComponent: React.FC = () => {
                       className="border-b border-zinc-800 last:border-0 hover:bg-zinc-800/30 transition-colors cursor-pointer"
                       onClick={() => handleVaultClick(vault)}
                     >
-                      <td className="p-4">
+                      <td className="p-3">
                         <div className="flex items-center">
                           <div className="w-8 h-8 min-w-[2rem] bg-zinc-100/10 rounded-full mr-3 flex items-center justify-center overflow-hidden">
                             {TOKEN_SVG_MAPPING[vault.name] ? (
@@ -614,30 +614,30 @@ const EarnComponent: React.FC = () => {
                           ))}
                         </div>
                       </td>
-                      <td className="p-4 pl-0 text-center">
+                      <td className="p-3 pl-0 text-left">
                         {isApyLoading ? (
-                          <div className="text-zinc-300 text-sm">
+                          <div className="text-zinc-300 font-medium w-full">
                             Loading...
                           </div>
                         ) : vault.name === "Liquid Move ETH" ? (
                           // Hardcoded 11% APY for Liquid Move ETH vault
-                          <div className="text-green-500 text-sm font-medium">
+                          <div className="text-green-500 font-medium font-mono w-full">
                             11.0%
                           </div>
                         ) : vault.name === "EIGEN Restaking" ? (
                           // Hardcoded 3.9% APY for EIGEN Restaking vault
-                          <div className="text-green-500 text-sm font-medium">
-                            3.9%
+                          <div className="text-green-500 font-medium font-mono w-full">
+                            3.1%
                           </div>
                         ) : vault.name === "The Bera ETH Vault" ||
                           vault.name === "The Bera BTC Vault" ||
                           !vault.contractAddress ||
                           !apyValues[vault.contractAddress] ? (
                           // For Bera vaults or N/A values when apyValues doesn't have a value or is null
-                          <div className="text-zinc-300 text-sm">
+                          <div className="text-zinc-300 w-full">
                             <Button
                               variant="link"
-                              className="h-auto p-0 text-xs text-amber-500 hover:text-amber-300"
+                              className="h-auto p-0 font-medium text-amber-500 hover:text-amber-300"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 window.open(vault.analyticsUrl, "_blank");
@@ -648,16 +648,16 @@ const EarnComponent: React.FC = () => {
                           </div>
                         ) : // Check if APY is a number and greater than zero
                         parseFloat(apyValues[vault.contractAddress]) > 0 ? (
-                          <div className="text-green-500 text-sm font-medium">
+                          <div className="text-green-500 font-medium font-mono w-full">
                             {apyValues[vault.contractAddress]}
                           </div>
                         ) : (
                           // For APY values that are 0 or negative
-                          <div className="text-zinc-300 text-sm">&lt;0.01%</div>
+                          <div className="text-zinc-300 font-medium font-mono w-full">&lt;0.01%</div>
                         )}
                       </td>
-                      <td className="p-4 text-right">
-                        <span className="text-amber-500 font-medium">
+                      <td className="p-3 text-right">
+                        <span className="text-amber-500 font-medium font-mono">
                           {isLoading
                             ? "Loading..."
                             : tvlValues[vault.id]
@@ -693,16 +693,13 @@ const EarnComponent: React.FC = () => {
 const PointsTab: React.FC = () => {
   // Local state to hold fetched points data
   const [pointsData, setPointsData] = useState<FormattedVedaPointsData | null>(null);
-
   // Loading & error flags
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // STEP 1: grab the "active" wallet out of your store
+  // STEP 1: grab the “active” wallet out of your store
   // getWalletBySourceChain() returns the currently‐selected WalletInfo or undefined
   const activeWallet = useWeb3Store((state) => state.getWalletBySourceChain());
-  const store = useWeb3Store((state) => state);
-
 
   // STEP 2: pull connectWallet() out of your wallet‐connection hook
   const { connectWallet } = useWalletConnection();
@@ -734,8 +731,9 @@ const PointsTab: React.FC = () => {
 
     fetchPoints();
   }, [activeWallet]);
+
   /**
-   * Helper to convert chain keys (e.g. "ethereum") into display names
+   * Helper to convert chain keys (e.g. “ethereum”) into display names
    */
   const getChainDisplayName = (name: string): string => {
     const displayNames: Record<string, string> = {
@@ -808,7 +806,7 @@ const PointsTab: React.FC = () => {
                     </div>
                   </div>
 
-                  {/* Vault‐level points table, or "no points yet" message */}
+                  {/* Vault‐level points table, or “no points yet” message */}
                   {chain.vaults.length > 0 ? (
                     <div className="p-3">
                       <table className="w-full">

--- a/src/app/(dapp)/earn/page.tsx
+++ b/src/app/(dapp)/earn/page.tsx
@@ -90,8 +90,11 @@ const EarnComponent: React.FC = () => {
   // Web3 store actions
   const setDestinationToken = useWeb3Store((state) => state.setDestinationToken);
   const setDestinationChain = useWeb3Store((state) => state.setDestinationChain);
+  const setSourceChain = useWeb3Store((state) => state.setSourceChain);
+  const setSourceToken = useWeb3Store((state) => state.setSourceToken);
   const addCustomToken = useWeb3Store((state) => state.addCustomToken);
   const tokensByCompositeKey = useWeb3Store((state) => state.tokensByCompositeKey);
+  const tokensByChainId = useWeb3Store((state) => state.tokensByChainId);
   const loadTokens = useWeb3Store((state) => state.loadTokens);
   const tokensLoading = useWeb3Store((state) => state.tokensLoading);
   const allTokensList = useWeb3Store((state) => state.allTokensList);
@@ -479,7 +482,7 @@ const EarnComponent: React.FC = () => {
   return (
     <div className="flex h-full w-full items-start justify-center min-h-[500px]">
       <div className="w-full flex flex-col items-center">
-        <div className="w-[880px] flex justify-center mb-6 mt-6">
+        <div className="w-[800px] flex justify-center mb-6 mt-6">
           {tabs.map((tab) => (
             <Button
               key={tab.id}
@@ -493,6 +496,12 @@ const EarnComponent: React.FC = () => {
                     tab.id === "stake" ||
                     tab.id === "points")
                 ) {
+                  if (tab.id === "points") {
+                    // set active chain to ethereum
+                    // set active token to ETH
+                    setSourceChain(chains.ethereum);
+                    setSourceToken(tokensByChainId[chains.ethereum.chainId].find(token => token.ticker === "ETH")!);
+                  }
                   setActiveTab(tab.id as "yield" | "stake" | "points");
                 }
               }}
@@ -510,24 +519,24 @@ const EarnComponent: React.FC = () => {
           ))}
         </div>
         {activeTab === "yield" && (
-          <div className="w-[880px] bg-zinc-900 rounded-[6px] overflow-hidden">
-            <div className="px-6 py-3">
+          <div className="w-[800px] bg-zinc-900 rounded-[6px] overflow-hidden">
+            <div className="px-8 py-4">
               <table className="w-full border-collapse">
                 <thead>
                   <tr className="border-b border-zinc-800">
-                    <th className="p-3 text-left text-zinc-400 font-medium w-[28%]">
+                    <th className="p-4 text-left text-zinc-400 font-medium w-[28%]">
                       Vault
                     </th>
-                    <th className="p-3 text-left text-zinc-400 font-medium w-[13%]">
+                    <th className="p-4 text-left text-zinc-400 font-medium w-[13%]">
                       Type
                     </th>
-                    <th className="p-3 text-left text-zinc-400 font-medium w-[31%] pr-0">
+                    <th className="p-4 text-left text-zinc-400 font-medium w-[31%] pr-0">
                       Token
                     </th>
-                    <th className="p-3 text-left text-zinc-400 font-medium w-[12%] pl-0">
+                    <th className="p-4 text-center text-zinc-400 font-medium w-[12%] pl-0">
                       APY
                     </th>
-                    <th className="p-3 text-right text-zinc-400 font-medium w-[16%]">
+                    <th className="p-4 text-right text-zinc-400 font-medium w-[16%]">
                       TVL
                     </th>
                   </tr>
@@ -539,7 +548,7 @@ const EarnComponent: React.FC = () => {
                       className="border-b border-zinc-800 last:border-0 hover:bg-zinc-800/30 transition-colors cursor-pointer"
                       onClick={() => handleVaultClick(vault)}
                     >
-                      <td className="p-3">
+                      <td className="p-4">
                         <div className="flex items-center">
                           <div className="w-8 h-8 min-w-[2rem] bg-zinc-100/10 rounded-full mr-3 flex items-center justify-center overflow-hidden">
                             {TOKEN_SVG_MAPPING[vault.name] ? (
@@ -605,30 +614,30 @@ const EarnComponent: React.FC = () => {
                           ))}
                         </div>
                       </td>
-                      <td className="p-3 pl-0 text-left">
+                      <td className="p-4 pl-0 text-center">
                         {isApyLoading ? (
-                          <div className="text-zinc-300 font-medium w-full">
+                          <div className="text-zinc-300 text-sm">
                             Loading...
                           </div>
                         ) : vault.name === "Liquid Move ETH" ? (
                           // Hardcoded 11% APY for Liquid Move ETH vault
-                          <div className="text-green-500 font-medium font-mono w-full">
+                          <div className="text-green-500 text-sm font-medium">
                             11.0%
                           </div>
                         ) : vault.name === "EIGEN Restaking" ? (
                           // Hardcoded 3.9% APY for EIGEN Restaking vault
-                          <div className="text-green-500 font-medium font-mono w-full">
-                            3.1%
+                          <div className="text-green-500 text-sm font-medium">
+                            3.9%
                           </div>
                         ) : vault.name === "The Bera ETH Vault" ||
                           vault.name === "The Bera BTC Vault" ||
                           !vault.contractAddress ||
                           !apyValues[vault.contractAddress] ? (
                           // For Bera vaults or N/A values when apyValues doesn't have a value or is null
-                          <div className="text-zinc-300 w-full">
+                          <div className="text-zinc-300 text-sm">
                             <Button
                               variant="link"
-                              className="h-auto p-0 font-medium text-amber-500 hover:text-amber-300"
+                              className="h-auto p-0 text-xs text-amber-500 hover:text-amber-300"
                               onClick={(e) => {
                                 e.stopPropagation();
                                 window.open(vault.analyticsUrl, "_blank");
@@ -639,16 +648,16 @@ const EarnComponent: React.FC = () => {
                           </div>
                         ) : // Check if APY is a number and greater than zero
                         parseFloat(apyValues[vault.contractAddress]) > 0 ? (
-                          <div className="text-green-500 font-medium font-mono w-full">
+                          <div className="text-green-500 text-sm font-medium">
                             {apyValues[vault.contractAddress]}
                           </div>
                         ) : (
                           // For APY values that are 0 or negative
-                          <div className="text-zinc-300 font-medium font-mono w-full">&lt;0.01%</div>
+                          <div className="text-zinc-300 text-sm">&lt;0.01%</div>
                         )}
                       </td>
-                      <td className="p-3 text-right">
-                        <span className="text-amber-500 font-medium font-mono">
+                      <td className="p-4 text-right">
+                        <span className="text-amber-500 font-medium">
                           {isLoading
                             ? "Loading..."
                             : tvlValues[vault.id]
@@ -684,13 +693,16 @@ const EarnComponent: React.FC = () => {
 const PointsTab: React.FC = () => {
   // Local state to hold fetched points data
   const [pointsData, setPointsData] = useState<FormattedVedaPointsData | null>(null);
+
   // Loading & error flags
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
 
-  // STEP 1: grab the “active” wallet out of your store
+  // STEP 1: grab the "active" wallet out of your store
   // getWalletBySourceChain() returns the currently‐selected WalletInfo or undefined
   const activeWallet = useWeb3Store((state) => state.getWalletBySourceChain());
+  const store = useWeb3Store((state) => state);
+
 
   // STEP 2: pull connectWallet() out of your wallet‐connection hook
   const { connectWallet } = useWalletConnection();
@@ -722,9 +734,8 @@ const PointsTab: React.FC = () => {
 
     fetchPoints();
   }, [activeWallet]);
-
   /**
-   * Helper to convert chain keys (e.g. “ethereum”) into display names
+   * Helper to convert chain keys (e.g. "ethereum") into display names
    */
   const getChainDisplayName = (name: string): string => {
     const displayNames: Record<string, string> = {
@@ -797,7 +808,7 @@ const PointsTab: React.FC = () => {
                     </div>
                   </div>
 
-                  {/* Vault‐level points table, or “no points yet” message */}
+                  {/* Vault‐level points table, or "no points yet" message */}
                   {chain.vaults.length > 0 ? (
                     <div className="p-3">
                       <table className="w-full">


### PR DESCRIPTION
This PR resolves a bug where points would not load because the source chain/token was not ETH.